### PR TITLE
Create `-O`, `--output-document` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The URI format is `irc://HOSTNAME[:PORT]/[#]CHANNEL[,[#]CHANNEL...]`. If the por
 
 The `-A`, `--no-acknowledge` flag may be used to suppress xget from returning file offsets as acknowledgements. Although it is DCC protocol to send these acknowledgements, many DCC senders don't require them&mdash;some will even abort the DCC transfer if too many acknowledgements are sent.
 
+The `-O`, `--output-document` flag may be used to create the file with a given name, instead of the name provided by the DCC sender. This flag accepts one argument: the new name and/or path of the file to be downloaded.
+
 ### Examples
 
 Request pack #34 from nick _super-duper-bot_ with `XDCC SEND` on the IRC network irc.sampel.net, after joining the IRC channel _#best-channel_.

--- a/xget.c
+++ b/xget.c
@@ -125,7 +125,7 @@ void event_dcc_send_req (irc_session_t *session, const char *nick, const char *a
 	}
 	else
 	{
-	    strlcpy (&cfg->filename[0], filename, sizeof cfg->filename);
+	    cfg->filename = strdup(filename);
 	}
     }
 
@@ -301,7 +301,7 @@ int main (int argc, char **argv)
 	{
 	    case 'O':
 		cfg.has_opt_output_document = true;
-		strlcpy (cfg.filename, optarg, sizeof cfg.filename);
+		cfg.filename = optarg;
 		break;
 	    case 'A':
 		cfg.no_ack = true;

--- a/xget.h
+++ b/xget.h
@@ -45,6 +45,9 @@ struct xdccGetConfig
 	// True if -A/--no-acknowledge (i.e. whether to send DCC acknowledgements).
 	bool no_ack;
 
+	// True if -O/--output-document.
+	bool has_opt_output_document;
+
 	// Synchronization primitives to safely share this struct between threads.
 	pthread_mutex_t mutex;
 	pthread_cond_t cv;

--- a/xget.h
+++ b/xget.h
@@ -1,7 +1,6 @@
 #ifndef XGET_H
 #define XGET_H
 
-#include <limits.h>
 #include <stdbool.h>
 #include <pthread.h>
 
@@ -25,7 +24,7 @@ struct xdccGetConfig
 	uint32_t numChannels;
 
 	// The name of the DCC file.
-	char filename[NAME_MAX];
+	char *filename;
 
 	// The size of the DCC file to be sent.
 	irc_dcc_size_t filesize;


### PR DESCRIPTION
This option can be used to download the file under a different name. Closes #28.